### PR TITLE
Fix api.ENGINE_URL and add api.FILE_MANAGER_URL

### DIFF
--- a/docs/Jupyter-Engine-Manager.imjoy.html
+++ b/docs/Jupyter-Engine-Manager.imjoy.html
@@ -12,7 +12,7 @@ via [mybinder.org](https://mybinder.org) or connect to a local Jupyter notebook 
     "type": "evil",
     "tags": [],
     "ui": "",
-    "version": "0.3.17",
+    "version": "0.3.18",
     "cover": "",
     "description": "This plugin uses Jupyter notebook servers as engine backend, it can either spwan Jupyter notebook servers via [mybinder.org](https://mybinder.org) or connect to a local Jupyter notebook server.",
     "icon": "extension",
@@ -23,8 +23,8 @@ via [mybinder.org](https://mybinder.org) or connect to a local Jupyter notebook 
     "permissions": [],
     "requirements": [
                     "https://lib.imjoy.io/static/jailed/_JailedSite.js",
-                    "https://imjoy-team.github.io/jupyter-engine-manager/index.bundle.js?version=0.3.17", 
-                    "https://imjoy-team.github.io/jupyter-engine-manager/Jupyter-Engine-Manager.script.js?version=0.3.17"
+                    "https://imjoy-team.github.io/jupyter-engine-manager/index.bundle.js?version=0.3.18", 
+                    "https://imjoy-team.github.io/jupyter-engine-manager/Jupyter-Engine-Manager.script.js?version=0.3.18"
                     ],
     "dependencies": [],
     "runnable": false,

--- a/docs/Jupyter-Engine-Manager.script.js
+++ b/docs/Jupyter-Engine-Manager.script.js
@@ -233,7 +233,7 @@ class JupyterServer {
       const {url, token} = await binder.startServer()
       server_url = url
       server_token = token
-      
+
       api.log('New server started: ' + url)
       
       // Connect to the notebook webserver.
@@ -719,6 +719,7 @@ class JupyterConnection {
     this._failHandler = () => {};
     this._disconnectHandler = () => {};
     this._loggingHandler = () => {};
+    this._messageHandler = () => {};
     this.kernel = kernel;
 
     const config_ = {
@@ -1023,7 +1024,7 @@ async function createNewEngine(engine_config){
     },
     getPlugin: ()=>{
     },
-    startPlugin: (config, interface)=>{
+    startPlugin: (config, imjoy_interface)=>{
       return new Promise(async (resolve, reject) => {
         if(!_connected){
           reject('Engine is disconnected.')
@@ -1044,7 +1045,7 @@ async function createNewEngine(engine_config){
               jserver.binder_confirmation_shown = true
             }
             
-            if(interface.TAG && interface.TAG.includes('GPU')){
+            if(imjoy_interface.TAG && imjoy_interface.TAG.includes('GPU')){
               const ret = await api.confirm({title: "📌Running plugin that requires GPU?", content: `It seems you are trying to run a plugin with GPU tag, however, please notice that the server on MyBinder.org does NOT support GPU. <br><br> Do you want to continue?`, confirm_text: 'Yes'})
               if(!ret){
                 reject("User canceled plugin execution.")
@@ -1116,7 +1117,9 @@ async function createNewEngine(engine_config){
               connection.disconnect()
               reject('disconnected')
             })
-            site.setInterface(interface);
+            imjoy_interface.ENGINE_URL = kernel.serverSettings.baseUrl;
+            imjoy_interface.FILE_MANAGER_URL = kernel.serverSettings.baseUrl;
+            site.setInterface(imjoy_interface);
           })
         }
         catch(e){

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyter-engine-manager",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "description": "Library to allow public interactive Jupyter notebooks",
   "main": "lib/index.bundle.js",
   "module": "src/index.js",

--- a/src/Jupyter-Engine-Manager.script.js
+++ b/src/Jupyter-Engine-Manager.script.js
@@ -233,7 +233,7 @@ class JupyterServer {
       const {url, token} = await binder.startServer()
       server_url = url
       server_token = token
-      
+
       api.log('New server started: ' + url)
       
       // Connect to the notebook webserver.
@@ -1024,7 +1024,7 @@ async function createNewEngine(engine_config){
     },
     getPlugin: ()=>{
     },
-    startPlugin: (config, interface)=>{
+    startPlugin: (config, imjoy_interface)=>{
       return new Promise(async (resolve, reject) => {
         if(!_connected){
           reject('Engine is disconnected.')
@@ -1045,7 +1045,7 @@ async function createNewEngine(engine_config){
               jserver.binder_confirmation_shown = true
             }
             
-            if(interface.TAG && interface.TAG.includes('GPU')){
+            if(imjoy_interface.TAG && imjoy_interface.TAG.includes('GPU')){
               const ret = await api.confirm({title: "📌Running plugin that requires GPU?", content: `It seems you are trying to run a plugin with GPU tag, however, please notice that the server on MyBinder.org does NOT support GPU. <br><br> Do you want to continue?`, confirm_text: 'Yes'})
               if(!ret){
                 reject("User canceled plugin execution.")
@@ -1117,7 +1117,9 @@ async function createNewEngine(engine_config){
               connection.disconnect()
               reject('disconnected')
             })
-            site.setInterface(interface);
+            imjoy_interface.ENGINE_URL = kernel.serverSettings.baseUrl;
+            imjoy_interface.FILE_MANAGER_URL = kernel.serverSettings.baseUrl;
+            site.setInterface(imjoy_interface);
           })
         }
         catch(e){


### PR DESCRIPTION
This PR fixes the value of api.ENGINE_URL, and also added a new api variable `api.FILE_MANAGER_URL`. It can be used to get the file manager associated with the plugin engine (e.g. `fm = await api.getFileManager(api.FILE_MANAGER_URL)`).

@muellerflorian 