### PR TITLE
switch back to iframe mode

### DIFF
--- a/docs/Jupyter-Engine-Manager.imjoy.html
+++ b/docs/Jupyter-Engine-Manager.imjoy.html
@@ -9,10 +9,10 @@ via [mybinder.org](https://mybinder.org) or connect to a local Jupyter notebook 
 <config lang="json">
 {
     "name": "Jupyter-Engine-Manager",
-    "type": "evil",
+    "type": "iframe",
     "tags": [],
     "ui": "",
-    "version": "0.3.18",
+    "version": "0.3.19",
     "cover": "",
     "description": "This plugin uses Jupyter notebook servers as engine backend, it can either spwan Jupyter notebook servers via [mybinder.org](https://mybinder.org) or connect to a local Jupyter notebook server.",
     "icon": "extension",
@@ -23,8 +23,8 @@ via [mybinder.org](https://mybinder.org) or connect to a local Jupyter notebook 
     "permissions": [],
     "requirements": [
                     "https://lib.imjoy.io/static/jailed/_JailedSite.js",
-                    "https://imjoy-team.github.io/jupyter-engine-manager/index.bundle.js?version=0.3.18", 
-                    "https://imjoy-team.github.io/jupyter-engine-manager/Jupyter-Engine-Manager.script.js?version=0.3.18"
+                    "https://imjoy-team.github.io/jupyter-engine-manager/index.bundle.js?version=0.3.19", 
+                    "https://imjoy-team.github.io/jupyter-engine-manager/Jupyter-Engine-Manager.script.js?version=0.3.19"
                     ],
     "dependencies": [],
     "runnable": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyter-engine-manager",
-  "version": "0.3.10",
+  "version": "0.3.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyter-engine-manager",
-  "version": "0.3.18",
+  "version": "0.3.19",
   "description": "Library to allow public interactive Jupyter notebooks",
   "main": "lib/index.bundle.js",
   "module": "src/index.js",

--- a/src/Jupyter-Engine-Manager.imjoy.html
+++ b/src/Jupyter-Engine-Manager.imjoy.html
@@ -9,7 +9,7 @@ via [mybinder.org](https://mybinder.org) or connect to a local Jupyter notebook 
 <config lang="json">
 {
     "name": "Jupyter-Engine-Manager",
-    "type": "evil",
+    "type": "iframe",
     "tags": [],
     "ui": "",
     "version": "PLUGIN_VERSION",


### PR DESCRIPTION
For some reason, the browser sometimes cannot connect to mybinder due to CORS in evil mode. 
This is a temporary fix for the issue, we should investigate more.