### PR TITLE
Passing file manager url as plugin api

### DIFF
--- a/docs/Jupyter-Engine-Manager.imjoy.html
+++ b/docs/Jupyter-Engine-Manager.imjoy.html
@@ -12,7 +12,7 @@ via [mybinder.org](https://mybinder.org) or connect to a local Jupyter notebook 
     "type": "iframe",
     "tags": [],
     "ui": "",
-    "version": "0.3.19",
+    "version": "0.3.20",
     "cover": "",
     "description": "This plugin uses Jupyter notebook servers as engine backend, it can either spwan Jupyter notebook servers via [mybinder.org](https://mybinder.org) or connect to a local Jupyter notebook server.",
     "icon": "extension",
@@ -23,8 +23,8 @@ via [mybinder.org](https://mybinder.org) or connect to a local Jupyter notebook 
     "permissions": [],
     "requirements": [
                     "https://lib.imjoy.io/static/jailed/_JailedSite.js",
-                    "https://imjoy-team.github.io/jupyter-engine-manager/index.bundle.js?version=0.3.19", 
-                    "https://imjoy-team.github.io/jupyter-engine-manager/Jupyter-Engine-Manager.script.js?version=0.3.19"
+                    "https://imjoy-team.github.io/jupyter-engine-manager/index.bundle.js?version=0.3.20", 
+                    "https://imjoy-team.github.io/jupyter-engine-manager/Jupyter-Engine-Manager.script.js?version=0.3.20"
                     ],
     "dependencies": [],
     "runnable": false,

--- a/docs/Jupyter-Engine-Manager.script.js
+++ b/docs/Jupyter-Engine-Manager.script.js
@@ -1103,6 +1103,8 @@ async function createNewEngine(engine_config){
               }
               site.onRemoteUpdate(() => {
                 const remote_api = site.getRemote();
+                remote_api.ENGINE_URL = engine_config.url
+                remote_api.FILE_MANAGER_URL = kernel.serverSettings.baseUrl
                 console.log(`plugin ${config.name} (id=${config.id}) initialized.`, remote_api)
                 api.showStatus(`🎉Plugin "${config.name}" is ready.`)
                 resolve(remote_api)
@@ -1117,7 +1119,7 @@ async function createNewEngine(engine_config){
               connection.disconnect()
               reject('disconnected')
             })
-            imjoy_interface.ENGINE_URL = kernel.serverSettings.baseUrl;
+            imjoy_interface.ENGINE_URL = engine_config.url;
             imjoy_interface.FILE_MANAGER_URL = kernel.serverSettings.baseUrl;
             site.setInterface(imjoy_interface);
           })
@@ -1129,9 +1131,8 @@ async function createNewEngine(engine_config){
         }
       });
     },
-    getEngineInfo() {
+    getEngineConfig() {
       return {}
-      // return engine.engine_info;
     },
     async getEngineStatus() {
       const kernels_info = []

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyter-engine-manager",
-  "version": "0.3.19",
+  "version": "0.3.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyter-engine-manager",
-  "version": "0.3.19",
+  "version": "0.3.20",
   "description": "Library to allow public interactive Jupyter notebooks",
   "main": "lib/index.bundle.js",
   "module": "src/index.js",

--- a/src/Jupyter-Engine-Manager.script.js
+++ b/src/Jupyter-Engine-Manager.script.js
@@ -1103,6 +1103,8 @@ async function createNewEngine(engine_config){
               }
               site.onRemoteUpdate(() => {
                 const remote_api = site.getRemote();
+                remote_api.ENGINE_URL = engine_config.url
+                remote_api.FILE_MANAGER_URL = kernel.serverSettings.baseUrl
                 console.log(`plugin ${config.name} (id=${config.id}) initialized.`, remote_api)
                 api.showStatus(`🎉Plugin "${config.name}" is ready.`)
                 resolve(remote_api)
@@ -1117,7 +1119,7 @@ async function createNewEngine(engine_config){
               connection.disconnect()
               reject('disconnected')
             })
-            imjoy_interface.ENGINE_URL = kernel.serverSettings.baseUrl;
+            imjoy_interface.ENGINE_URL = engine_config.url;
             imjoy_interface.FILE_MANAGER_URL = kernel.serverSettings.baseUrl;
             site.setInterface(imjoy_interface);
           })
@@ -1129,9 +1131,8 @@ async function createNewEngine(engine_config){
         }
       });
     },
-    getEngineInfo() {
+    getEngineConfig() {
       return {}
-      // return engine.engine_info;
     },
     async getEngineStatus() {
       const kernels_info = []


### PR DESCRIPTION
This PR sends FILE_MANAGER_URL back to ImJoy to allow ImJoy know which file_manager is the current plugin running.