### PR TITLE
Switch back to evil plugin type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyter-engine-manager",
-  "version": "0.3.23",
+  "version": "0.3.24",
   "description": "Library to allow public interactive Jupyter notebooks",
   "main": "lib/index.bundle.js",
   "module": "src/index.js",

--- a/src/Jupyter-Engine-Manager.imjoy.html
+++ b/src/Jupyter-Engine-Manager.imjoy.html
@@ -9,7 +9,7 @@ via [mybinder.org](https://mybinder.org) or connect to a local Jupyter notebook 
 <config lang="json">
 {
     "name": "Jupyter-Engine-Manager",
-    "type": "iframe",
+    "type": "evil",
     "tags": [],
     "ui": "",
     "version": "PLUGIN_VERSION",


### PR DESCRIPTION
Due to a bug fix in the ImJoy app (https://github.com/imjoy-team/ImJoy/pull/332) we can now switch back to evil plugin type to gain potential performance improvement.