### PR TITLE
Add show File Dialog support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyter-engine-manager",
-  "version": "0.3.27",
+  "version": "0.3.28",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyter-engine-manager",
-  "version": "0.3.27",
+  "version": "0.3.28",
   "description": "Library to allow public interactive Jupyter notebooks",
   "main": "lib/index.bundle.js",
   "module": "src/index.js",

--- a/src/Jupyter-Engine-Manager.imjoy.html
+++ b/src/Jupyter-Engine-Manager.imjoy.html
@@ -26,7 +26,7 @@ via [mybinder.org](https://mybinder.org) or connect to a local Jupyter notebook 
                     "STATIC_SERVER_URL/index.bundle.js?version=PLUGIN_VERSION", 
                     "STATIC_SERVER_URL/Jupyter-Engine-Manager.script.js?version=PLUGIN_VERSION"
                     ],
-    "dependencies": [],
+    "dependencies": ["STATIC_SERVER_URL/Jupyter-elFinder.imjoy.html"],
     "runnable": false,
     "flags": ["engine-factory", 
             "engine", 

--- a/src/Jupyter-Engine-Manager.script.js
+++ b/src/Jupyter-Engine-Manager.script.js
@@ -270,7 +270,7 @@ class JupyterServer {
         name: name,
         url: url,
         showFileDialog: enable_show_file_dialog ? async ()=>{
-          api.showDialog({type: "elFinder", name: "File Manager " + name, data: {serverUrl: server_url, token: token}})
+          api.showDialog({type: "Jupyter-elFinder", name: "File Manager " + name, data: {serverUrl: server_url, token: token}})
         } : null,
         async listFiles(root, type, recursive){
           root = normalizePath(root)

--- a/src/Jupyter-Engine-Manager.script.js
+++ b/src/Jupyter-Engine-Manager.script.js
@@ -262,10 +262,16 @@ class JupyterServer {
       let _file_list = []
       let fail_count = 20;
       name = name.pathname === '/' ? name.hostname: name.pathname ;
+      if(await pingServer(server_url + 'elfinder'+'?token='+token)){
+        enable_show_file_dialog = true;
+      }
       await api.register({
         type: 'file-manager',
         name: name,
         url: url,
+        showFileDialog: enable_show_file_dialog ? async ()=>{
+          api.showDialog({type: "elFinder", name: "File Manager " + name, data: {serverUrl: server_url, token: token}})
+        } : null,
         async listFiles(root, type, recursive){
           root = normalizePath(root)
           const file_url = `${url}api/contents/${encodeURIComponent(root)}?token=${token}&${ Math.random().toString(36).substr(2, 9)}`;

--- a/src/Jupyter-elFinder.imjoy.html
+++ b/src/Jupyter-elFinder.imjoy.html
@@ -1,0 +1,68 @@
+<docs lang="markdown">
+
+# Jupyter elFinder
+
+This is a wrapper plugin for working with https://github.com/imjoy-team/jupyter-engine-manager and https://github.com/imjoy-team/jupyter-elfinder
+</docs>
+
+<config lang="json">
+{
+    "name": "Jupyter-elFinder",
+    "type": "window",
+    "tags": [],
+    "ui": "",
+    "version": "0.1.0",
+    "cover": "",
+    "description": "A rich file browser for managing files on remote servers.",
+    "icon": "extension",
+    "inputs": null,
+    "outputs": null,
+    "api_version": "0.1.7",
+    "env": "",
+    "permissions": [],
+    "requirements": [],
+    "dependencies": [],
+    "defaults": {"w": 20, "h": 10, "as_dialog": true},
+    "runnable": false
+}
+</config>
+
+<script lang="javascript">
+
+class ImJoyPlugin {
+    async setup() {
+    
+    }
+
+    async run(ctx) {
+        let serverUrl = ( ctx.data && ctx.data.serverUrl ) || 'http://127.0.0.1:9527';
+        const proxyUrl = ( ctx.data && ctx.data.proxyUrl )|| '/elfinder';
+        if(!ctx.data.token) api.showStatus('WARNING: No token is set for elfinder.');
+        if(serverUrl.endsWith('/')) serverUrl = serverUrl.slice(0, serverUrl.length-1)
+        window.ELFINDER_CONFIG = {
+            static_url: serverUrl + proxyUrl + '/static', // https://imjoy-team.github.io/jupyter-elfinder/jupyter_elfinder/static/main.js
+            connector_url: serverUrl + proxyUrl + '/connector',
+            connector_query: ctx.data.token?'token=' + ctx.data.token : null,
+            file_base_url: serverUrl,
+        }
+        var script = document.createElement('script');
+        script.type = 'text/javascript';
+        script.setAttribute('data-main', window.ELFINDER_CONFIG['static_url'] + '/main.js');
+        script.src = '//cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js';
+        document.getElementsByTagName('head')[0].appendChild(script);
+    }
+}
+
+api.export(new ImJoyPlugin())
+</script>
+
+<window lang="html">
+    <div id="elfinder">Loading elFinder...</div>
+</window>
+
+<style lang="css">
+.elfinder-quicklook-titlebar-icon {
+    margin-top: 0px!important;
+}
+</style>
+    


### PR DESCRIPTION
This PR support show File Dialog with jupyter-elfinder: https://github.com/imjoy-team/jupyter-elfinder

<img width="1422" alt="Screenshot 2020-03-20 at 11 56 13" src="https://user-images.githubusercontent.com/478667/77157520-cf64f380-6aa1-11ea-9397-6eb357a8957f.png">

To use it, do `pip install -U imjoy && pip install -U jupyter-elfinder[jupyter]` then start `imjoy --jupyter`.
