### PR TITLE
pin the version of imjoy-core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyter-engine-manager",
-  "version": "0.3.33",
+  "version": "0.3.36",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyter-engine-manager",
-  "version": "0.3.35",
+  "version": "0.3.36",
   "description": "Library to allow public interactive Jupyter notebooks",
   "main": "lib/index.bundle.js",
   "module": "src/index.js",

--- a/src/Jupyter-Engine-Manager.imjoy.html
+++ b/src/Jupyter-Engine-Manager.imjoy.html
@@ -22,7 +22,7 @@ via [mybinder.org](https://mybinder.org) or connect to a local Jupyter notebook 
     "env": "",
     "permissions": [],
     "requirements": [
-                    "https://lib.imjoy.io/static/jailed/_JailedSite.js",
+                    "https://cdn.jsdelivr.net/npm/imjoy-core@0.11.13/dist/static/jailed/_JailedSite.js",
                     "STATIC_SERVER_URL/index.bundle.js?version=PLUGIN_VERSION", 
                     "STATIC_SERVER_URL/Jupyter-Engine-Manager.script.js?version=PLUGIN_VERSION"
                     ],


### PR DESCRIPTION
This is to solve the _JailedSite.js file which has been removed during a recent update to the core.